### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -147,8 +147,8 @@ terraform plan
 ### Configuration file
 
 You can use a configuration file to specify your credentials. The
-file location must be `$HOME/.zscaler/credentials.json` on Linux and OS X, or
-`"%USERPROFILE%\.zscaler/credentials.json"` for Windows users.
+file location must be `$HOME/.zpa/credentials.json` on Linux and OS X, or
+`"%USERPROFILE%\.zpa/credentials.json"` for Windows users.
 If we fail to detect credentials inline, or in the environment variable, Terraform will check
 this location.
 
@@ -164,7 +164,8 @@ credentials.json file:
 {
   "zpa_client_id":"zpa_client_id",
   "zpa_client_secret": "zpa_client_secret",
-  "zpa_customer_id": "zpa_customer_id"
+  "zpa_customer_id": "zpa_customer_id",
+  "zpa_cloud": "zpa_cloud"
 }
 ```
 


### PR DESCRIPTION
Fixing error with documentation. JSON credentials path zpa provider block is looking for is ~/.zpa/credentials.json, not ~/.zscaler/credentials.json. Additionally, the required zpa_cloud key is missing from the example credentials.json.

With file in original path ($HOME/.zscaler/credentials.json), terraform fails with:

error:Could not open credentials file, needs to contain one json object with keys: zpa_client_id, zpa_client_secret, zpa_customer_id, and zpa_cloud. open /home/user/.zpa/credentials.json: no such file or directory

Steps to reproduce:

Create ~/.zscaler/credentials.json per existing docs

Create main.tf with body:

```
terraform {
  required_providers {
    zpa = {
      source = "zscaler/zpa"
      version = "~> 2.81.1"
    }
  }
}

provider "zpa" {
}

data "zpa_application_segment" "this" {
    name = "existing_app_segment"
}
```

terraform init
terraform plan

Result:

```
$ terraform plan

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: failed configuring the provided
│
│   with provider["registry.terraform.io/zscaler/zpa"],
│   on main.tf line 16, in provider "zpa":
│   16: provider "zpa" {
│
│ error:Could not open credentials file, needs to contain one json object with keys: zpa_client_id, zpa_client_secret, zpa_customer_id, and zpa_cloud. open /home/user/.zpa/credentials.json: no such file or directory
╵
```